### PR TITLE
Add Laravel 13 support, drop PHP 8.1

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,13 +19,10 @@ jobs:
         include:
           - laravel: 13.*
             testbench: 11.*
-            carbon: ^3.0
           - laravel: 12.*
             testbench: 10.*
-            carbon: ^3.0
           - laravel: 11.*
             testbench: 9.*
-            carbon: ^2.67
         exclude:
           - laravel: 13.*
             php: 8.2
@@ -50,7 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,19 +13,22 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.2, 8.1]
-        laravel: [11.*, 10.*]
+        php: [8.4, 8.3, 8.2]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.0
+          - laravel: 12.*
+            testbench: 10.*
+            carbon: ^3.0
           - laravel: 11.*
             testbench: 9.*
-            carbon: ^3.0
-          - laravel: 10.*
-            testbench: 8.*
             carbon: ^2.67
         exclude:
-          - laravel: 11.*
-            php: 8.1
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,21 +16,21 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/database": "^10.0|^11.0",
-        "illuminate/support": "^10.0|^11.0",
-        "spatie/laravel-package-tools": "^1.14.1"
+        "php": "^8.2",
+        "illuminate/database": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
+        "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.7",
-        "larastan/larastan": "^2.0.1",
-        "nunomaduro/collision": "^7.10.0|^8.1.1",
-        "orchestra/testbench": "^8.0|^9.0",
-        "pestphp/pest": "^2.34",
-        "pestphp/pest-plugin-laravel": "^2.3",
-        "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "larastan/larastan": "^3.0",
+        "nunomaduro/collision": "^8.1",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,5 +9,4 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/src/Macros/PaginationLimit.php
+++ b/src/Macros/PaginationLimit.php
@@ -9,7 +9,7 @@ class PaginationLimit implements HelperMacro
     public function __invoke(): \Closure
     {
         return function (int $default = 16, int $max = 48): int {
-            $limit = request()->get('limit') ?? $default;
+            $limit = request()->input('limit') ?? $default;
 
             return min($limit, $max);
         };

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -24,7 +24,7 @@ it('anonymizeFilename', function (?string $name, ?string $ext) {
     $expect->toEndWith($ext);
     $this->assertNotEquals($expect, $filename);
 })->with([
-    ['filename' => '', 'ext' => ''],
+    ['name' => '', 'ext' => ''],
     ['name' => 'test', 'ext' => '.zip'],
     ['name' => 'test-test', 'ext' => '.jpg'],
 ]);


### PR DESCRIPTION
## Summary
- Add Laravel 13 support (and Laravel 12), drop Laravel 10
- Bump minimum PHP to 8.2 (drop 8.1)
- Update dev dependencies for the new Laravel range (testbench 9/10/11, pest 3|4, larastan 3, phpstan 2)

## Changes
- **composer.json**: `php ^8.2`, `illuminate/* ^11.0|^12.0|^13.0`, `spatie/laravel-package-tools ^1.16`; dev deps bumped accordingly
- **CI run-tests.yml**: matrix PHP `8.2-8.4` × Laravel `11/12/13`; L13 excluded on PHP 8.2 (requires 8.3+)
- **CI phpstan.yml**: PHP `8.1` → `8.3`
- **phpstan.neon.dist**: remove `checkMissingIterableValueType` (removed in PHPStan 2)
- **PaginationLimit**: `Request::get()` → `Request::input()` (deprecated in Laravel 13)
- **tests**: fix `anonymizeFilename` dataset key (`filename` → `name`) for Pest 4 named arguments

## Verification (local, PHP 8.3)
- `composer update --prefer-stable` → Laravel 13 / testbench 11 / pest 4, clean resolution
- `vendor/bin/pest` → 71 passed
- `vendor/bin/phpstan analyse` → no errors
- `composer format` → no style changes
- `--prefer-lowest` sanity check on Laravel 11 → resolves and 71 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)